### PR TITLE
build(gh-workflow): add release workflow

### DIFF
--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: '.python-version'
+      - name: Install dependencies
+        run: |
+          pip install poetry
+          poetry install
+      - name: Build dist
+        run: |
+          poetry build
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./dist
+
+  pypi-publish:
+    name: Publish to PyPI
+    needs: ['build']
+    environment: 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v3
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages_dir: artifact/


### PR DESCRIPTION
Add `.github/workflows/cd-release.yaml` file for automating publications to PyPI.