### PR TITLE
build(gh-workflow): attempt to fix OIDC issue

### DIFF
--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -8,8 +8,7 @@ on:
 jobs:
   release-build:
     runs-on: ubuntu-latest
-    environment:
-      name: release
+    environment: release
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Error: Valid token, but no corresponding publisher. Possibly the yaml for the environment was wrong.